### PR TITLE
support mysqlbinlog and mysql in a custom location

### DIFF
--- a/bin/apply_diff_relay_logs
+++ b/bin/apply_diff_relay_logs
@@ -67,6 +67,8 @@ GetOptions(
     disable_log_bin=i
     no_apply
     manager_version=s
+    client_bindir=s
+    client_libdir=s
     debug
     /,
 ) or pod2usage(1);
@@ -93,6 +95,9 @@ unless ( $opt{datadir} ) {
 if ( $opt{ssh_options} ) {
   $MHA::NodeConst::SSH_OPT_ALIVE = $opt{ssh_options};
 }
+
+my $_mysql = MHA::NodeUtil::client_cli_prefix("mysql", $opt{client_bindir}, $opt{client_libdir});
+my $_mysqlbinlog = MHA::NodeUtil::client_cli_prefix("mysqlbinlog", $opt{client_bindir}, $opt{client_libdir});
 
 my $_binlog_manager;
 my $_find_logname_only = 0;
@@ -137,7 +142,7 @@ sub fast_find_pos() {
     # Checking binlog is readable from this position
     unless (
       system(
-"mysqlbinlog --start-position=$start_rlp --stop-position=$start_rlp $_binlog_manager->{dir}/$_binlog_manager->{end_log} > /dev/null"
+"$_mysqlbinlog --start-position=$start_rlp --stop-position=$start_rlp $_binlog_manager->{dir}/$_binlog_manager->{end_log} > /dev/null"
       )
       )
     {
@@ -225,7 +230,7 @@ sub do_generate($$$) {
 }
 
 sub use_binary_mode() {
-  my $v = `mysql --version`;
+  my $v = `$_mysql --version`;
   my $mysqlclient_version;
   chomp($v);
   if ( $v =~ /Distrib (\d+\.\d+\.\d+)/ ) {
@@ -258,7 +263,7 @@ sub apply_diff($$) {
 
   if ( $opt{handle_raw_binlog} ) {
     if ( $#diffs == 0 ) {
-      $command = "mysqlbinlog $apply_files ";
+      $command = "$_mysqlbinlog $apply_files ";
     }
     else {
       my $out =
@@ -266,7 +271,7 @@ sub apply_diff($$) {
       MHA::NodeUtil::drop_file_if($out);
       $_binlog_manager->concat_generated_binlogs( \@diffs, $out );
       print "All apply target binary logs are concatinated at $out .\n";
-      $command = "mysqlbinlog $out ";
+      $command = "$_mysqlbinlog $out ";
     }
     $command .= $_binlog_manager->get_apply_arg();
   }
@@ -282,7 +287,7 @@ sub apply_diff($$) {
   escape_mysql_account();
 
   $command .=
-" | mysql $binary_mode --user=$_escaped_slave_user --password=$_escaped_slave_pass --host=$opt{slave_ip} --port=$opt{slave_port} -vvv --unbuffered > $err_file 2>&1";
+" | $_mysql $binary_mode --user=$_escaped_slave_user --password=$_escaped_slave_pass --host=$opt{slave_ip} --port=$opt{slave_port} -vvv --unbuffered > $err_file 2>&1";
 
   # applying relay log
   print
@@ -359,7 +364,7 @@ sub check() {
 
   if (
     $rc = system(
-"mysql --user=$_escaped_slave_user --password=$_escaped_slave_pass --host=$opt{slave_ip} --port=$opt{slave_port} -e \"set sql_log_bin=0; create table if not exists mysql.apply_diff_relay_logs_test(id int); insert into mysql.apply_diff_relay_logs_test values(1); update mysql.apply_diff_relay_logs_test set id=id+1 where id=1; delete from mysql.apply_diff_relay_logs_test; drop table mysql.apply_diff_relay_logs_test;\""
+"$_mysql --user=$_escaped_slave_user --password=$_escaped_slave_pass --host=$opt{slave_ip} --port=$opt{slave_port} -e \"set sql_log_bin=0; create table if not exists mysql.apply_diff_relay_logs_test(id int); insert into mysql.apply_diff_relay_logs_test values(1); update mysql.apply_diff_relay_logs_test set id=id+1 where id=1; delete from mysql.apply_diff_relay_logs_test; drop table mysql.apply_diff_relay_logs_test;\""
     )
     )
   {
@@ -372,7 +377,7 @@ sub check() {
 
   if (
     $rc = system(
-"mysqlbinlog $_binlog_manager->{dir}/$_binlog_manager->{end_log} --start-position=4 --stop-position=4 > $workfile"
+"$_mysqlbinlog $_binlog_manager->{dir}/$_binlog_manager->{end_log} --start-position=4 --stop-position=4 > $workfile"
     )
     )
   {
@@ -471,6 +476,8 @@ sub main() {
       handle_raw_binlog => $opt{handle_raw_binlog},
       disable_log_bin   => $opt{disable_log_bin},
       mysql_version     => $opt{target_version},
+      client_bindir     => $opt{client_bindir},
+      client_libdir     => $opt{client_libdir},
       debug             => $opt{debug},
     );
     if (!$opt{handle_raw_binlog}

--- a/bin/save_binary_logs
+++ b/bin/save_binary_logs
@@ -44,6 +44,8 @@ GetOptions(
     handle_raw_binlog=i
     disable_log_bin=i
     manager_version=s
+    client_bindir=s
+    client_libdir=s
     debug
     /,
 ) or pod2usage(1);
@@ -92,6 +94,8 @@ sub main {
       handle_raw_binlog => $opt{handle_raw_binlog},
       disable_log_bin   => $opt{disable_log_bin},
       mysql_version     => $opt{oldest_version},
+      client_bindir     => $opt{client_bindir},
+      client_libdir     => $opt{client_libdir},
       debug             => $opt{debug},
     );
     $_binlog_manager->init_mysqlbinlog() unless ( $opt{handle_raw_binlog} );


### PR DESCRIPTION
Add client_bindir and client_libdir command line options; if specified, favor customized clients to stock clients. Use configuration directives provided by mha4mysql-manager to activate these feature, see corresponding pull request.
