### PR TITLE
Added find -L to dereference symbolic links

### DIFF
--- a/bin/purge_relay_logs
+++ b/bin/purge_relay_logs
@@ -125,7 +125,7 @@ sub remove_hardlinked_relay_logs() {
       . "under $opt{workdir}.." );
   croak
     if system(
-"find $opt{workdir} -maxdepth 1 -type f -name '$_binlog_manager->{prefix}*' | xargs rm -f"
+"find -L $opt{workdir} -maxdepth 1 -type f -name '$_binlog_manager->{prefix}*' | xargs rm -f"
     );
   print(" done.\n");
 }


### PR DESCRIPTION
I think using symbolic links is not so rare, so I propose to add -L option.
