### PR TITLE
Added port number in workfile name

### DIFF
--- a/bin/apply_diff_relay_logs
+++ b/bin/apply_diff_relay_logs
@@ -376,7 +376,7 @@ sub check() {
   }
   print " done.\n";
   print "    Testing mysqlbinlog output..";
-  my $workfile = "$opt{workdir}/slavediff_tmp_$opt{slave_host}.log";
+  my $workfile = "$opt{workdir}/slavediff_tmp_$opt{slave_host}_$opt{slave_port}.log";
 
   if (
     $rc = system(


### PR DESCRIPTION
I faced a problem when I use MHA in multi-instance environment as follows.

server1:3306 in app1
server1:3307 in app2

if manager for app1 and manager for app2 execute at the same time, apply_diff_relay_logs script will use a single workfile.
I added port number in workfile name to solve this problem.
