### PR TITLE
Adding --socket parameter to bin/purge_relay_logs

### DIFF
--- a/bin/purge_relay_logs
+++ b/bin/purge_relay_logs
@@ -42,6 +42,7 @@ GetOptions(
     password=s
     host=s
     port=i
+    socket=s
     disable_relay_log_purge
     use_hardlink=i
     /,
@@ -174,6 +175,9 @@ sub main {
 
     $_binlog_manager = new MHA::BinlogManager();
     my $dsn = "DBI:mysql:;host=$opt{host};port=$opt{port}";
+    if ( defined($opt{socket} ) ) {
+      $dsn .= ";mysql_socket=$opt{socket}";
+    }
     my $dbh =
       DBI->connect( $dsn, $opt{user}, $opt{password},
       { PrintError => 0, RaiseError => 1 } );


### PR DESCRIPTION
It's sometimes needed when using multiply instances and socket connection (instead TCP).
