### PR TITLE
Add --defaults_file flag to bin/purge_relay_logs.

### DIFF
--- a/bin/purge_relay_logs
+++ b/bin/purge_relay_logs
@@ -43,6 +43,7 @@ GetOptions(
     host=s
     port=i
     socket=s
+    defaults_file=s
     disable_relay_log_purge
     use_hardlink=i
     /,
@@ -177,6 +178,9 @@ sub main {
     my $dsn = "DBI:mysql:;host=$opt{host};port=$opt{port}";
     if ( defined($opt{socket} ) ) {
       $dsn .= ";mysql_socket=$opt{socket}";
+    }
+    if ( defined($opt{defaults_file} ) ) {
+      $dsn .= ";mysql_read_default_file=$opt{defaults_file}";
     }
     my $dbh =
       DBI->connect( $dsn, $opt{user}, $opt{password},


### PR DESCRIPTION
Avoid the need to pass passwords on the commandline when the DSN
supports loading config files.

See https://metacpan.org/pod/DBD::mysql#mysql_read_default_file
