### PR TITLE
MHA IPv6-only support

### DIFF
--- a/bin/apply_diff_relay_logs
+++ b/bin/apply_diff_relay_logs
@@ -459,11 +459,11 @@ sub generate_and_send {
     )
     )
   {
-    croak "ERROR: scp %s:%s to %s(%d) failed!\n", hostname(),
+    croak "ERROR: scp [%s]:%s to %s(%d) failed!\n", hostname(),
       $opt{diff_file_readtolatest}, $scp_user_host, $opt{scp_port};
   }
   else {
-    printf " scp %s:%s to %s(%d) succeeded.\n", hostname(),
+    printf " scp [%s]:%s to %s(%d) succeeded.\n", hostname(),
       $opt{diff_file_readtolatest}, $scp_user_host, $opt{scp_port};
   }
   return 0;

--- a/bin/purge_relay_logs
+++ b/bin/purge_relay_logs
@@ -175,7 +175,7 @@ sub main {
     print "$start: purge_relay_logs script started.\n";
 
     $_binlog_manager = new MHA::BinlogManager();
-    my $dsn = "DBI:mysql:;host=$opt{host};port=$opt{port}";
+    my $dsn = "DBI:mysql:;host=[$opt{host}];port=$opt{port}";
     if ( defined( $opt{socket} ) ) {
       $dsn .= ";mysql_socket=$opt{socket}";
     }

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Homepage: http://code.google.com/p/mysql-master-ha/
 
 Package: mha4mysql-node
 Architecture: all
-Depends: ${misc:Depends}, ${perl:Depends}, libdbi-perl, libdbd-mysql-perl
+Depends: ${misc:Depends}, ${perl:Depends}, libdbi-perl, libdbd-mysql-perl (>= 4.031)
 Description: Master High Availability Manager and Tools for MySQL, Node Package

--- a/lib/MHA/NodeUtil.pm
+++ b/lib/MHA/NodeUtil.pm
@@ -86,11 +86,11 @@ sub file_copy {
   my ( $from, $to );
   if ($to_remote) {
     $from = $local_file;
-    $to   = "$ssh_user_host:$remote_file";
+    $to   = "[$ssh_user_host]:$remote_file";
   }
   else {
     $to   = $local_file;
-    $from = "$ssh_user_host:$remote_file";
+    $from = "[$ssh_user_host]:$remote_file";
   }
 
   my $max_retries = 3;
@@ -159,6 +159,14 @@ sub get_ip {
     # We take the first ip address that is returned by getaddrinfo
     ( $err, $addr_host ) = getnameinfo($bin_addr_host[0]->{addr}, NI_NUMERICHOST);
     croak "Failed to convert IP address for host $host: $err\n" if $err;
+
+    # for IPv6 (and it works with IPv4 and hostnames as well):
+    # - DBD-MySQL expects [::] format
+    # - scp requires [::] format
+    # - ssh requires :: format
+    # - mysql tools require :: format
+    # The code in MHA is expected to use [] when it is running scp
+    # when it connects with DBD-MySQL
 
     return $addr_host;
   }

--- a/lib/MHA/NodeUtil.pm
+++ b/lib/MHA/NodeUtil.pm
@@ -26,7 +26,7 @@ use Carp qw(croak);
 use MHA::NodeConst;
 use File::Path;
 use Errno();
-use Socket qw(getaddrinfo getnameinfo);
+use Socket qw(NI_NUMERICHOST getaddrinfo getnameinfo);
 
 sub create_dir_if($) {
   my $dir = shift;
@@ -157,7 +157,7 @@ sub get_ip {
     croak "Failed to get IP address on host $host: $err\n" if $err;
 
     # We take the first ip address that is returned by getaddrinfo
-    ( $err, $addr_host ) = getnameinfo($bin_addr_host[0]->{addr});
+    ( $err, $addr_host ) = getnameinfo($bin_addr_host[0]->{addr}, NI_NUMERICHOST);
     croak "Failed to convert IP address for host $host: $err\n" if $err;
 
     return $addr_host;

--- a/rpm/masterha_node.spec
+++ b/rpm/masterha_node.spec
@@ -9,7 +9,7 @@ URL: http://code.google.com/p/mysql-master-ha/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 BuildRequires: perl(ExtUtils::MakeMaker) >= 6.30
-Requires: perl(DBD::mysql)
+Requires: perl(DBD::mysql) >= 4.031
 Requires: perl(DBI)
 Source0: mha4mysql-node-%{version}.tar.gz
 


### PR DESCRIPTION
This patch brings MHA IPv6-only support by replacing the use of gethostbyname with getaddrinfo in order to support ipv6MHA ipv6 only support