### PR TITLE
add compatibility with MariaDB & Percona Server's 'enforce_storage_engine'

### DIFF
--- a/bin/apply_diff_relay_logs
+++ b/bin/apply_diff_relay_logs
@@ -367,7 +367,7 @@ sub check() {
 
   if (
     $rc = system(
-"$_mysql --user=$_escaped_slave_user --password=$_escaped_slave_pass --host=$opt{slave_ip} --port=$opt{slave_port} -e \"set sql_log_bin=0; create table if not exists mysql.apply_diff_relay_logs_test(id int) engine myisam; insert into mysql.apply_diff_relay_logs_test values(1); update mysql.apply_diff_relay_logs_test set id=id+1 where id=1; delete from mysql.apply_diff_relay_logs_test; drop table mysql.apply_diff_relay_logs_test;\""
+"$_mysql --user=$_escaped_slave_user --password=$_escaped_slave_pass --host=$opt{slave_ip} --port=$opt{slave_port} -e \"set sql_log_bin=0; create table if not exists mysql.apply_diff_relay_logs_test(id int); insert into mysql.apply_diff_relay_logs_test values(1); update mysql.apply_diff_relay_logs_test set id=id+1 where id=1; delete from mysql.apply_diff_relay_logs_test; drop table mysql.apply_diff_relay_logs_test;\""
     )
     )
   {


### PR DESCRIPTION
the test function in apply_diff_relay_logs creates a test table which is forced to be myisam. This is not compatible with certain mysql settings which enforce a certain storage engine (https://www.percona.com/doc/percona-server/5.6/management/enforce_engine.html and https://mariadb.com/kb/en/mariadb/server-system-variables/#enforce_storage_engine). This patch just creates a table with the default storage engine