### PR TITLE
Fix redundant argument error on sprintf in parse_mysql_major_version()

### DIFF
--- a/lib/MHA/NodeUtil.pm
+++ b/lib/MHA/NodeUtil.pm
@@ -198,7 +198,9 @@ sub parse_mysql_version($) {
 
 sub parse_mysql_major_version($) {
   my $str = shift;
-  my $result = sprintf( '%03d%03d', $str =~ m/(\d+)/g );
+  $str =~ /(\d+)\.(\d+)/;
+  my $strmajor = "$1.$2";
+  my $result = sprintf( '%03d%03d', $strmajor =~ m/(\d+)/g );
   return $result;
 }
 


### PR DESCRIPTION
This small patch fixes an error I've been encountering while running MHA with Perl 5.22.

Perl 5.22.x doesn't ignore extra arguments in sprintf anymore and instead throws an error if less formats are available than variables to be transformed into them.

It's probably not the most elegant way to do this, so please feel free to either adapt this code to your liking or let me know how you would like me to change my patch.

Best,

– Guillaume Ceccarelli
