### PR TITLE
Added missing build dependency for libmodule-install-perl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: mha4mysql-node
 Section: perl
 Priority: optional
-Build-Depends: debhelper (>= 7.2.13)
+Build-Depends: debhelper (>= 7.2.13), libmodule-install-perl
 Build-Depends-Indep: perl
 Maintainer: Yoshinori Matsunobu <Yoshinori.Matsunobu@gmail.com>
 Standards-Version: 3.9.1


### PR DESCRIPTION
Similar problem decribed in this PR  for mha4mysql-manager https://github.com/yoshinorim/mha4mysql-manager/pull/82

Build failing without this dependency installed.
