### PR TITLE
Fix dsn for ipv4

### DIFF
--- a/bin/apply_diff_relay_logs
+++ b/bin/apply_diff_relay_logs
@@ -496,11 +496,13 @@ sub generate_and_send {
     )
     )
   {
-    croak "ERROR: scp [%s]:%s to %s(%d) failed!\n", hostname(),
+    my $dsn_host = hostname() =~ m{:} ? '[' . hostname() . ']' : hostname();
+    croak "ERROR: scp %s:%s to %s(%d) failed!\n", $dsn_host,
       $opt{diff_file_readtolatest}, $scp_user_host, $opt{scp_port};
   }
   else {
-    printf " scp [%s]:%s to %s(%d) succeeded.\n", hostname(),
+    my $dsn_host = hostname() =~ m{:} ? '[' . hostname() . ']' : hostname();
+    printf " scp [%s]:%s to %s(%d) succeeded.\n", $dsn_host,
       $opt{diff_file_readtolatest}, $scp_user_host, $opt{scp_port};
   }
   return 0;

--- a/bin/apply_diff_relay_logs
+++ b/bin/apply_diff_relay_logs
@@ -502,7 +502,7 @@ sub generate_and_send {
   }
   else {
     my $dsn_host = hostname() =~ m{:} ? '[' . hostname() . ']' : hostname();
-    printf " scp [%s]:%s to %s(%d) succeeded.\n", $dsn_host,
+    printf " scp %s:%s to %s(%d) succeeded.\n", $dsn_host,
       $opt{diff_file_readtolatest}, $scp_user_host, $opt{scp_port};
   }
   return 0;

--- a/bin/purge_relay_logs
+++ b/bin/purge_relay_logs
@@ -175,7 +175,8 @@ sub main {
     print "$start: purge_relay_logs script started.\n";
 
     $_binlog_manager = new MHA::BinlogManager();
-    my $dsn = "DBI:mysql:;host=[$opt{host}];port=$opt{port}";
+    my $dsn_host = $opt{host} =~ m{:} ? '[' . $opt{host} . ']' : $opt{host};
+    my $dsn = "DBI:mysql:;host=$dsn_host;port=$opt{port}";
     if ( defined( $opt{socket} ) ) {
       $dsn .= ";mysql_socket=$opt{socket}";
     }

--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Homepage: http://code.google.com/p/mysql-master-ha/
 
 Package: mha4mysql-node
 Architecture: all
-Depends: ${misc:Depends}, ${perl:Depends}, libdbi-perl, libdbd-mysql-perl (>= 4.031)
+Depends: ${misc:Depends}, ${perl:Depends}, libdbi-perl, libdbd-mysql-perl
 Description: Master High Availability Manager and Tools for MySQL, Node Package

--- a/lib/MHA/NodeUtil.pm
+++ b/lib/MHA/NodeUtil.pm
@@ -81,8 +81,8 @@ sub file_copy {
   my $log_output  = shift;
   my $ssh_port    = shift;
   $ssh_port = 22 unless ($ssh_port);
-
-  my $ssh_user_host = $ssh_user . '@[' . $ssh_host . ']';
+  my $dsn_host = $ssh_host =~ m{:} ? '[' . $ssh_host . ']' : $ssh_host;
+  my $ssh_user_host = $ssh_user . '@' . $dsn_host;
   my ( $from, $to );
   if ($to_remote) {
     $from = $local_file;

--- a/lib/MHA/SlaveUtil.pm
+++ b/lib/MHA/SlaveUtil.pm
@@ -234,7 +234,8 @@ sub check_if_super_read_only {
   my $user = shift;
   my $pass = shift;
   # create databasehandle to check super_read_only setting
-  my $dsn = "DBI:mysql:;host=[$ip];port=$port";
+  my $dsn_host = $ip =~ m{:} ? '[' . $ip . ']' : $ip;
+  my $dsn = "DBI:mysql:;host=$dsn_host;port=$port";
   my $dbh =
     DBI->connect( $dsn, $user, MHA::NodeUtil::unescape_for_shell($pass),
     { PrintError => 0, RaiseError => 1 } );

--- a/rpm/masterha_node.spec
+++ b/rpm/masterha_node.spec
@@ -9,7 +9,7 @@ URL: http://code.google.com/p/mysql-master-ha/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 BuildRequires: perl(ExtUtils::MakeMaker) >= 6.30
-Requires: perl(DBD::mysql) >= 4.031
+Requires: perl(DBD::mysql)
 Requires: perl(DBI)
 Source0: mha4mysql-node-%{version}.tar.gz
 


### PR DESCRIPTION
check if : is in hostname, then use ipv6 [] notation, if not, use hostname without []. This allows older perl dbd mysql versions to work for ipv4

mha4mysql-manager related PR: https://github.com/yoshinorim/mha4mysql-manager/pull/94/files