### PR TITLE
Update purge_relay_logs

### DIFF
--- a/bin/purge_relay_logs
+++ b/bin/purge_relay_logs
@@ -228,7 +228,7 @@ sub main {
       $current_relay_log = $_binlog_manager->{cur_log};
     }
 
-    if ( $opt{use_hard_link} ) {
+    if ( $opt{use_hardlink} ) {
       remove_hardlinked_relay_logs();
       croak if ( hardlink_relay_logs($current_relay_log) );
     }
@@ -247,7 +247,7 @@ sub main {
     print " ok.\n";
 
     MHA::SlaveUtil::release_failover_advisory_lock($dbh);
-    if ( $opt{use_hard_link} ) {
+    if ( $opt{use_hardlink} ) {
       remove_hardlinked_relay_logs();
     }
     my $end = MHA::NodeUtil::current_time();


### PR DESCRIPTION
there is a bug in purge_relay_logs. It leads to can't use the option of use_hard_link。
the option named use_hardlink，but when it is used as use_hard_link。so the option isn't used at all.