### PR TITLE
support long length mysql version

### DIFF
--- a/lib/MHA/NodeUtil.pm
+++ b/lib/MHA/NodeUtil.pm
@@ -192,7 +192,7 @@ sub check_manager_version {
 
 sub parse_mysql_version($) {
   my $str = shift;
-  my $result = sprintf( '%03d%03d%03d', $str =~ m/(\d+)/g );
+  my $result = sprintf( '%03d%03d%03d', ($str =~ m/(\d+)/g)[0 .. 2] );
   return $result;
 }
 
@@ -200,7 +200,7 @@ sub parse_mysql_major_version($) {
   my $str = shift;
   $str =~ /(\d+)\.(\d+)/;
   my $strmajor = "$1.$2";
-  my $result = sprintf( '%03d%03d', $strmajor =~ m/(\d+)/g );
+  my $result = sprintf( '%03d%03d', ($strmajor =~ m/(\d+)/g)[0 .. 2] );
   return $result;
 }
 


### PR DESCRIPTION
Support long length mysql version such as `5.7.23-0ubuntu0.16.04.1-log`  

This fixes `Redundant argument in sprintf` error on perl 5.22 as mentioned in issue #35 
Pull request #23 didn't fix this issue for me.

Adapted fix from https://github.com/innotop/innotop/issues/122
