### PR TITLE
NodeUtil.pm: slight bug on version extraction

### DIFF
--- a/lib/MHA/NodeUtil.pm
+++ b/lib/MHA/NodeUtil.pm
@@ -191,16 +191,16 @@ sub check_manager_version {
 }
 
 sub parse_mysql_version($) {
-  my $str = shift;
-  my $result = sprintf( '%03d%03d%03d', $str =~ m/(\d+)/g );
+  my $str = shift;  
+  my @a_str = $str =~ m/(\d+)/g;
+  my $result = sprintf( '%03d%03d%03d', splice(@a_str,0,3) );
   return $result;
 }
 
 sub parse_mysql_major_version($) {
-  my $str = shift;
-  $str =~ /(\d+)\.(\d+)/;
-  my $strmajor = "$1.$2";
-  my $result = sprintf( '%03d%03d', $strmajor =~ m/(\d+)/g );
+  my $str = shift;  
+  my @a_str = $str =~ m/(\d+)/g;
+  my $result = sprintf( '%03d%03d', splice(@a_str,0,2) );
   return $result;
 }
 


### PR DESCRIPTION
Caused by an error as an example:
vagrant@node_manager:~$ /usr/local/bin/masterha_check_repl --conf=/etc/app1.cnf
Fri May  3 00:59:43 2019 - [warning] Global configuration file /etc/masterha_default.cnf not found. Skipping.
Fri May  3 00:59:43 2019 - [info] Reading application default configuration from /etc/app1.cnf..
Fri May  3 00:59:43 2019 - [info] Reading server configuration from /etc/app1.cnf..
Fri May  3 00:59:43 2019 - [info] MHA::MasterMonitor version 0.58.
Fri May  3 00:59:44 2019 - [error][/usr/local/share/perl/5.26.1/MHA/MasterMonitor.pm, ln427] Error happened on checking configurations. Redundant argument in sprintf at /usr/local/share/perl/5.26.1/MHA/NodeUtil.pm line 195.
Fri May  3 00:59:44 2019 - [error][/usr/local/share/perl/5.26.1/MHA/MasterMonitor.pm, ln525] Error happened on monitoring servers.
Fri May  3 00:59:44 2019 - [info] Got exit code 1 (Not master dead).

It would be more readable and easy to follow using array and then splice based only on the indexes needed to be parsed in Major and Minor version